### PR TITLE
Add derive Clone to high_level::Event

### DIFF
--- a/src/high_level.rs
+++ b/src/high_level.rs
@@ -113,7 +113,7 @@ impl From<FanotifyResponse> for u32 {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Event {
     pub fd: i32,
     pub path: String,


### PR DESCRIPTION
All the members already implement Clone and it shouldn't be problematic to copy a FD 