### PR TITLE
Impl `Drop` for `Event` and provide an API to clone events

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fanotify-rs"
-version = "0.3.1"
+version = "0.3.2"
 authors = ["zhanglei <mrzhang.lei@outlook.com>", "n01e0 <noleo@vanillabeans.mobi>", "Philip Woolford <woolford.philip@gmail.com>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
This removes the derive of `Clone` for the `Event` type, but provides the function `try_clone` that duplicates the file descriptor. As the file descriptor is no longer closed during parsing, the `Event` type now implements `Drop` too.