### PR TITLE
Fix typos, punctuation and doc comments' markdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,3 @@
-
 # Change Log
 All notable changes to this project will be documented in this file.
  
@@ -7,7 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [0.3.1] - 2024-02-08
 
-No other changes
+No other changes.
 
 ## [0.3.1-rc3] - 2024-02-08
 
@@ -24,25 +23,25 @@ Rename `Fanotify` functions and stop eating registration errors.
 Added `FanotifyBuilder` to provide finer-grained control on what options are supplied to the libc call without directly using the low_level methods.
 
 ### Changed
-Rename `Fanotify::new_with_blocking` and `Fanotify::new_with_nonblocking`
-The above functions now bubble up registration errors
+Rename `Fanotify::new_with_blocking` and `Fanotify::new_with_nonblocking`.
+The above functions now bubble up registration errors.
  
 ## [0.3.1-rc1] - 2024-02-04
  
-Big update and refactor. The overral structure remains the same, but includes a number of fixes included in outstanding PRs. The update have been checked against current test cases and the PoC, but need review before release.
+Big update and refactor. The overall structure remains the same, but includes a number of fixes included in outstanding PRs. The update have been checked against current test cases and the PoC, but need review before release.
  
 ### Added
-Implemented `AsFd` for `Fanotify` to allow borrowing of the internal file descriptor (e.g. for polling)
+Implemented `AsFd` for `Fanotify` to allow borrowing of the internal file descriptor (e.g. for polling).
  
 ### Changed
-Widened the implementation of `FanotifyPath` to all implementors of `AsRef<OsStr>`, but removed the direct implementation for `String` due to conflict.
+Widened the implementation of `FanotifyPath` to all implementers of `AsRef<OsStr>`, but removed the direct implementation for `String` due to a conflict.
 Update dependencies, and removed the dependency on lazy_static.
 Updated the crate to 2021 edition.
-Changed type of PID in the `Event` type as `pid_t` is generally implemented as `int` in libc implementations.
-Changed `to_fan_class` to to copy instead of borrow as the type is `Copy`.
+Changed type of PID in the `Event` type, as `pid_t` is generally implemented as `int` in libc implementations.
+Changed `to_fan_class` to copy instead of borrow, as the type is `Copy`.
 Renamed `low_level::fanotify_response` to `low_level::FanotifyResponse` to keep with Rust's naming convention.
-Removed crate definitions of some library flags, and replaced with re-exports from `libc`.
-Removed setting that forced inclusion of debug symbols in release mode.
+Removed crate definitions of some library flags, and replaced them with re-exports from `libc`.
+Removed the setting that forced inclusion of debug symbols in release mode.
  
 ### Fixed
 Fixed the type for calling `fanotify_mark` on aarch64

--- a/demo/with_poll/README.md
+++ b/demo/with_poll/README.md
@@ -14,8 +14,8 @@ $ sudo ./run.sh
    ```bash
    sudo ./run.sh
    ```
-2. Navigate to new temporary folder
+2. Navigate to a new temporary folder
     ```bash
     `pwd`/tmp
     ```
-3. Create or change files in `tmp` folder to see output on console running `run.sh`
+3. Create or change the files in `tmp` folder to see the output on the console running `run.sh`

--- a/demo/with_poll/src/main.rs
+++ b/demo/with_poll/src/main.rs
@@ -11,7 +11,7 @@ fn main() {
     fd.add_mountpoint(
         FAN_OPEN_EXEC | FAN_CLOSE_WRITE,
         app.get_one::<String>("path")
-            .expect("We can unwrap here as clap enforces the existence of `path`"),
+            .expect("We can unwrap here, as clap enforces the existence of `path`"),
     )
     .unwrap();
 

--- a/src/high_level.rs
+++ b/src/high_level.rs
@@ -21,8 +21,8 @@ pub struct Fanotify {
     fd: i32,
 }
 
-// SAFETY: the `fanotify_*` functions are thread safe, and file descriptors are safe for
-// sharing betweent threads if they are used in threadsafe functions
+// SAFETY: the `fanotify_*` functions are thread safe, and file descriptors are safe to
+// share between threads if they are used in threadsafe functions
 unsafe impl Send for Fanotify {}
 unsafe impl Sync for Fanotify {}
 

--- a/tests/high_level.rs
+++ b/tests/high_level.rs
@@ -5,7 +5,7 @@ fn high_level_test() {
         FAN_OPEN,
     };
     use std::io::{Read, Write};
-    let ft = Fanotify::new_blocking(FanotifyMode::NOTIF).expect("Error regitering fanotify listener");
+    let ft = Fanotify::new_blocking(FanotifyMode::NOTIF).expect("Error registering a fanotify listener");
     ft.add_path(
         FAN_ACCESS | FAN_CLOSE | FAN_EVENT_ON_CHILD | FAN_MODIFY | FAN_ONDIR | FAN_OPEN,
         "/tmp",


### PR DESCRIPTION
To be precise,
- like 4 typos
- a few missing dots at the ends of the sentences
- a lot of missing backticks around the names of constants or fields, whatever
- mostly replacing `<br>` with empty lines like most of the rust docs do
- mostly moving the words between the lines to have them consistent and no wider than 100 chars (now that i think about it, it was stupid, but most of the std lib docs are like that)

my english is terrible sometimes so pls check if it is worth merging